### PR TITLE
Make btns buttons, inherit font family

### DIFF
--- a/src/index.pug
+++ b/src/index.pug
@@ -77,53 +77,53 @@ html
 
       .button-demo
         h3.h5 .btn
-        btn.btn Click Me
+        button.btn Click Me
 
         h3.h5 .btn.btn-primary
-        btn.btn.btn-primary Click Me
+        button.btn.btn-primary Click Me
 
         h3.h5 .btn.btn-secondary
-        btn.btn.btn-secondary Click Me
+        button.btn.btn-secondary Click Me
 
         h3.h5 .btn.btn-success
-        btn.btn.btn-success Click Me
+        button.btn.btn-success Click Me
 
         h3.h5 .btn.btn-info
-        btn.btn.btn-info Click Me
+        button.btn.btn-info Click Me
 
         h3.h5 .btn.btn-warning
-        btn.btn.btn-warning Click Me
+        button.btn.btn-warning Click Me
 
         h3.h5 .btn.btn-danger
-        btn.btn.btn-danger Click Me
+        button.btn.btn-danger Click Me
 
         h3.h5 .btn.btn-link
-        btn.btn.btn-link Click Me
+        button.btn.btn-link Click Me
 
       h2.display-4 Outline Buttons
 
       .button-demo
 
         h3.h5 .btn.btn-outline-primary
-        btn.btn.btn-outline-primary Click Me
+        button.btn.btn-outline-primary Click Me
 
         h3.h5 .btn.btn-outline-secondary
-        btn.btn.btn-outline-secondary Click Me
+        button.btn.btn-outline-secondary Click Me
 
         h3.h5 .btn.btn-outline-success
-        btn.btn.btn-outline-success Click Me
+        button.btn.btn-outline-success Click Me
 
         h3.h5 .btn.btn-outline-info
-        btn.btn.btn-outline-info Click Me
+        button.btn.btn-outline-info Click Me
 
         h3.h5 .btn.btn-outline-warning
-        btn.btn.btn-outline-warning Click Me
+        button.btn.btn-outline-warning Click Me
 
         h3.h5 .btn.btn-outline-danger
-        btn.btn.btn-outline-danger Click Me
+        button.btn.btn-outline-danger Click Me
 
         h3.h5 .btn.btn-outline-link
-        btn.btn.btn-outline-link Click Me
+        button.btn.btn-outline-link Click Me
 
       hr
       h2.display-4 Typography

--- a/src/index.pug
+++ b/src/index.pug
@@ -76,8 +76,6 @@ html
       h2.display-4 Buttons
 
       .button-demo
-        h3.h5 .btn
-        button.btn Click Me
 
         h3.h5 .btn.btn-primary
         button.btn.btn-primary Click Me
@@ -121,9 +119,6 @@ html
 
         h3.h5 .btn.btn-outline-danger
         button.btn.btn-outline-danger Click Me
-
-        h3.h5 .btn.btn-outline-link
-        button.btn.btn-outline-link Click Me
 
       hr
       h2.display-4 Typography

--- a/src/scss/demo.scss
+++ b/src/scss/demo.scss
@@ -76,7 +76,7 @@
   .h5 {
     margin-bottom: 0;
   }
-  btn {
+  .btn {
     margin-bottom: 2rem;
   }
 }

--- a/src/scss/mofo-bootstrap.scss
+++ b/src/scss/mofo-bootstrap.scss
@@ -16,6 +16,7 @@
 
 // Reset and dependencies
 @import '../../node_modules/bootstrap/scss/normalize';
+@import './overrides/normalize';
 @import '../../node_modules/bootstrap/scss/print';
 
 // Core CSS

--- a/src/scss/overrides/_normalize.scss
+++ b/src/scss/overrides/_normalize.scss
@@ -1,0 +1,8 @@
+//This undoes setting of these elements' font to sans-serif by normalize
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+}


### PR DESCRIPTION
Normalize was resetting font family of buttons to a general sans-serif. This still has theoretical problems of inheriting fonts for specific sections, but I don’t know that it’s going to be a realistic issue for us. The other option was to set the font-family of those elements to the font variable string we use, but I don't feel like it really makes a difference, as that can lead to cascade override issues later on.

Also makes the index page use `<button>` instead of the fictional `<btn>`

Closes #102 