### PR TITLE
[Docs] README.md - adding separators to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ For the moment it's recommended that you use one of two methods to include the c
 
 It's not currently advisable that you extend and compile the mofo-bootstrap SCSS in your project. SCSS doesn't ([currently](https://github.com/sass/sass/issues/739)) allow for dynamic import paths, which complicates things when mofo-bootstrap becomes a module. We're working on a reasonable approach for allowing this...
 
+Table of Contents (ToC)
+=======================
+
+* [Setup for Development](#setup-for-development)
+* [File Structure](#file-structure)
+* [File Naming Conventions](#file-naming conventions)
+* [Linting](#linting)
+* [Deploying](#deploying)
+
+---
+
 ## Setup for Development
 
 Run the following commands in your terminal:
@@ -23,6 +34,8 @@ Run the following commands in your terminal:
 1. `git clone https://github.com/mozilla/mofo-bootstrap.git && cd mofo-bootstrap`
 2. `npm i`
 3. `npm start`
+
+---
 
 ## File Structure
 
@@ -38,17 +51,23 @@ src/
     └── mofo-bootstrap.scss <- Primary entry point that defines all imports.
 ```
 
+---
+
 ## File Naming Conventions
 
 - All files should be named in `hyphenated-lowercase`
 - SCSS modules/partials should be prefixed with an underscore (`_`)
 - Bootstrap overrides should be named after their sibling. (For example: `/src/scss/overrides/_type.scss` and `bootstrap/scss/_type.scss`)
 
+---
+
 ## Linting
 
 To lint your Sass code, run `npm run test:sass`
 
 [Travis](https://travis-ci.org/mozilla/mofo-bootstrap) is connected to this task and your pull requests will fail if this test doesn't pass locally.
+
+---
 
 ## Deploying
 


### PR DESCRIPTION
## [Docs] README.md - adding separators to README.md file

<sub>**this PR does basically aim at:**</sub>
- <sub>*adding separators to README.md file*</sub>
- <sub>*adding Table of Contents (ToC) to README.md file*</sub>

---

<sub>**main motivation behind such**</sub>
- <sub>*improving overall document acessebility*</sub>